### PR TITLE
Update NKDCode128Barcode.m

### DIFF
--- a/NKDCode128Barcode.m
+++ b/NKDCode128Barcode.m
@@ -854,6 +854,12 @@
 			return @"11110100010";
 		case 99:
 			return @"10111011110";
+		case 100:
+			return @"10111101110";
+		case 101:
+			return @"11101011110";
+		case 102:
+			return @"11110101110";
     }
     return @"";
 }


### PR DESCRIPTION
Check digit calculation is a modulo 103 checksum, but _encodeNumberPair only has switch-case from 0 to 99.
Check character encoding fails when checksum value is 100, 101 or 102.

Fix : Added bar/space pattern for values 100, 101 and 102
